### PR TITLE
Remove strict version from "fresco" for RN 59

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,6 +40,6 @@ repositories {
 
 dependencies {
     compileOnly 'com.facebook.react:react-native:+'
-    implementation 'com.facebook.fresco:fresco:0.11.0'
+    implementation 'com.facebook.fresco:fresco:+'
     implementation 'me.relex:photodraweeview:1.0.0'
 }


### PR DESCRIPTION
RN 59 uses a different (probably higher) version of `com.facbeook.fresco:fresco`. This change would allow for any version to be used instead of strictly basing it on version 0.11.0.